### PR TITLE
feat: support token scope list for scope validation

### DIFF
--- a/gin/jose.go
+++ b/gin/jose.go
@@ -9,8 +9,8 @@ import (
 	"strings"
 
 	auth0 "github.com/auth0-community/go-auth0"
-	krakendjose "github.com/devopsfaith/krakend-jose"
 	"github.com/gin-gonic/gin"
+	krakendjose "github.com/instill-ai/krakend-jose"
 	"github.com/luraproject/lura/config"
 	"github.com/luraproject/lura/logging"
 	"github.com/luraproject/lura/proxy"

--- a/gin/jose_example_test.go
+++ b/gin/jose_example_test.go
@@ -10,8 +10,8 @@ import (
 	"strings"
 	"time"
 
-	krakendjose "github.com/devopsfaith/krakend-jose"
 	"github.com/gin-gonic/gin"
+	krakendjose "github.com/instill-ai/krakend-jose"
 	"github.com/luraproject/lura/config"
 	"github.com/luraproject/lura/logging"
 	"github.com/luraproject/lura/proxy"

--- a/go.mod
+++ b/go.mod
@@ -1,11 +1,11 @@
-module github.com/devopsfaith/krakend-jose
+module github.com/instill-ai/krakend-jose
 
 go 1.13
 
 require (
 	github.com/auth0-community/go-auth0 v1.0.0
 	github.com/gin-gonic/gin v1.5.0
-	github.com/luraproject/lura v1.4.0 // indirect
+	github.com/luraproject/lura v1.4.0
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	gocloud.dev v0.20.0
 	gocloud.dev/secrets/hashivault v0.20.0

--- a/go.sum
+++ b/go.sum
@@ -152,10 +152,8 @@ github.com/golang/mock v1.4.0/go.mod h1:UOMv5ysSaYNkG+OFQykRIcU/QvvxJf3p21QfJ2Bt
 github.com/golang/mock v1.4.1/go.mod h1:UOMv5ysSaYNkG+OFQykRIcU/QvvxJf3p21QfJ2Bt3cw=
 github.com/golang/mock v1.4.3/go.mod h1:UOMv5ysSaYNkG+OFQykRIcU/QvvxJf3p21QfJ2Bt3cw=
 github.com/golang/protobuf v1.0.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
-github.com/golang/protobuf v1.2.0 h1:P3YflyNX/ehuJFLhxviNdFxQPkGK5cDcApsge1SqnvM=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
-github.com/golang/protobuf v1.3.2 h1:6nsPYzhq5kReh6QImI3k5qWzO4PEbvbIW2cwSfR/6xs=
 github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.3/go.mod h1:vzj43D7+SQXF/4pzW/hwtAqwc6iTitCiVSaWz5lYuqw=
 github.com/golang/protobuf v1.3.4/go.mod h1:vzj43D7+SQXF/4pzW/hwtAqwc6iTitCiVSaWz5lYuqw=
@@ -419,7 +417,6 @@ golang.org/x/sys v0.0.0-20190507160741-ecd444e8653b/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190606165138-5da285871e9c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190624142023-c5567b49c5d0/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190726091711-fc99dfbffb4e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20190813064441-fde4db37ae7a h1:aYOabOQFp6Vj6W1F80affTUvO9UxmJRx8K0gsfABByQ=
 golang.org/x/sys v0.0.0-20190813064441-fde4db37ae7a/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191001151750-bb3f8db39f24/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191112214154-59a1497f0cea/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -585,7 +582,6 @@ gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/go-playground/assert.v1 v1.2.1 h1:xoYuJVE7KT85PYWrN730RguIQO0ePzVRfFMXadIrXTM=
 gopkg.in/go-playground/assert.v1 v1.2.1/go.mod h1:9RXL0bg/zibRAgZUYszZSwO/z8Y/a8bDuhia5mkpMnE=
-gopkg.in/go-playground/validator.v8 v8.18.2 h1:lFB4DoMU6B626w8ny76MV7VX6W2VHct2GVOI3xgiMrQ=
 gopkg.in/go-playground/validator.v8 v8.18.2/go.mod h1:RX2a/7Ha8BgOhfk7j780h4/u/RRjR0eouCJSH80/M2Y=
 gopkg.in/go-playground/validator.v9 v9.29.1 h1:SvGtYmN60a5CVKTOzMSyfzWDeZRxRuGvRQyEAKbw1xc=
 gopkg.in/go-playground/validator.v9 v9.29.1/go.mod h1:+c9/zcJMFNgbLvly1L1V+PpxWdVbfP1avr/N00E2vyQ=

--- a/jose.go
+++ b/jose.go
@@ -152,12 +152,32 @@ func ScopesAllMatcher(scopesKey string, claims map[string]interface{}, requiredS
 	if !ok {
 		return false
 	}
-	scopeClaim, ok := tmp.(string)
+
+	scopes, ok := tmp.([]interface{})
+	if ok {
+		if len(scopes) > 0 {
+			for _, rScope := range requiredScopes {
+				matched := false
+				for _, pScope := range scopes {
+					if rScope == fmt.Sprintf("%s", pScope) {
+						matched = true
+					}
+				}
+				if matched == false { // required scope was not found --> immediately return
+					return false
+				}
+			}
+			// all required scopes have been found in provided (claims) scopes
+			return true
+		}
+	}
+
+	scopeString, ok := tmp.(string)
 	if !ok {
 		return false
 	}
 
-	presentScopes := strings.Split(scopeClaim, " ")
+	presentScopes := strings.Split(scopeString, " ")
 	if len(presentScopes) > 0 {
 		for _, rScope := range requiredScopes {
 			matched := false
@@ -197,6 +217,23 @@ func ScopesAnyMatcher(scopesKey string, claims map[string]interface{}, requiredS
 	if !ok {
 		return false
 	}
+
+	scopes, ok := tmp.([]interface{})
+	if ok {
+		if len(scopes) > 0 {
+			for _, rScope := range requiredScopes {
+				for _, pScope := range scopes {
+					if rScope == fmt.Sprintf("%s", pScope) {
+						return true // found any of the required scopes --> return
+					}
+				}
+			}
+
+			// none of the scopes have been found in provided (claims) scopes
+			return false
+		}
+	}
+
 	scopeClaim, ok := tmp.(string)
 	if !ok {
 		return false

--- a/jose_test.go
+++ b/jose_test.go
@@ -150,6 +150,71 @@ func TestScopesAllMatcher(t *testing.T) {
 		expected       bool
 	}{
 		{
+			name:           "all_simple_success_for_scope_slice",
+			scopesKey:      "scope",
+			claims:         map[string]interface{}{"scope": []interface{}{"a", "b"}},
+			requiredScopes: []string{"a", "b"},
+			expected:       true,
+		},
+		{
+			name:           "all_simple_fail_for_scope_slice",
+			scopesKey:      "scope",
+			claims:         map[string]interface{}{"scope": []interface{}{"a", "b"}},
+			requiredScopes: []string{"c"},
+			expected:       false,
+		},
+		{
+			name:           "all_missingone_fail_for_scope_slice",
+			scopesKey:      "scope",
+			claims:         map[string]interface{}{"scope": []interface{}{"a", "b"}},
+			requiredScopes: []string{"a", "b", "c"},
+			expected:       false,
+		},
+		{
+			name:           "all_one_simple_success_for_scope_slice",
+			scopesKey:      "scope",
+			claims:         map[string]interface{}{"scope": []interface{}{"a", "b"}},
+			requiredScopes: []string{"b"},
+			expected:       true,
+		},
+		{
+			name:           "all_no_req_scopes_success_for_scope_slice",
+			scopesKey:      "scope",
+			claims:         map[string]interface{}{"scope": []interface{}{"a", "b"}},
+			requiredScopes: []string{},
+			expected:       true,
+		},
+		{
+			name:           "all_struct_success_for_scope_slice",
+			scopesKey:      "data.scope",
+			claims:         map[string]interface{}{"data": map[string]interface{}{"scope": []interface{}{"a", "b"}}},
+			requiredScopes: []string{"a", "b"},
+			expected:       true,
+		},
+		{
+			name:      "all_deep_struct_success_for_scope_slice",
+			scopesKey: "data.data.data.data.data.data.data.scope",
+			claims: map[string]interface{}{
+				"data": map[string]interface{}{
+					"data": map[string]interface{}{
+						"data": map[string]interface{}{
+							"data": map[string]interface{}{
+								"data": map[string]interface{}{
+									"data": map[string]interface{}{
+										"data": map[string]interface{}{
+											"scope": []interface{}{"a", "b"},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			requiredScopes: []string{"a", "b"},
+			expected:       true,
+		},
+		{
 			name:           "all_simple_success",
 			scopesKey:      "scope",
 			claims:         map[string]interface{}{"scope": "a b"},
@@ -230,6 +295,71 @@ func TestScopesAnyMatcher(t *testing.T) {
 		requiredScopes []string
 		expected       bool
 	}{
+		{
+			name:           "any_simple_success_for_scope_slice",
+			scopesKey:      "scope",
+			claims:         map[string]interface{}{"scope": []interface{}{"a", "b"}},
+			requiredScopes: []string{"a", "b"},
+			expected:       true,
+		},
+		{
+			name:           "any_simple_fail_for_scope_slice",
+			scopesKey:      "scope",
+			claims:         map[string]interface{}{"scope": []interface{}{"a", "b"}},
+			requiredScopes: []string{"c"},
+			expected:       false,
+		},
+		{
+			name:           "any_missingone_success_for_scope_slice",
+			scopesKey:      "scope",
+			claims:         map[string]interface{}{"scope": []interface{}{"a"}},
+			requiredScopes: []string{"a", "b"},
+			expected:       true,
+		},
+		{
+			name:           "any_one_simple_success_for_scope_slice",
+			scopesKey:      "scope",
+			claims:         map[string]interface{}{"scope": []interface{}{"a", "b"}},
+			requiredScopes: []string{"b"},
+			expected:       true,
+		},
+		{
+			name:           "any_no_req_scopes_success_for_scope_slice",
+			scopesKey:      "scope",
+			claims:         map[string]interface{}{"scope": []interface{}{"a", "b"}},
+			requiredScopes: []string{},
+			expected:       true,
+		},
+		{
+			name:           "any_struct_success_for_scope_slice",
+			scopesKey:      "data.scope",
+			claims:         map[string]interface{}{"data": map[string]interface{}{"scope": []interface{}{"a"}}},
+			requiredScopes: []string{"a", "b"},
+			expected:       true,
+		},
+		{
+			name:      "any_deep_struct_success_for_scope_slice",
+			scopesKey: "data.data.data.data.data.data.data.scope",
+			claims: map[string]interface{}{
+				"data": map[string]interface{}{
+					"data": map[string]interface{}{
+						"data": map[string]interface{}{
+							"data": map[string]interface{}{
+								"data": map[string]interface{}{
+									"data": map[string]interface{}{
+										"data": map[string]interface{}{
+											"scope": []interface{}{"a"},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			requiredScopes: []string{"a", "b"},
+			expected:       true,
+		},
 		{
 			name:           "any_simple_success",
 			scopesKey:      "scope",

--- a/jwk.go
+++ b/jwk.go
@@ -19,7 +19,7 @@ import (
 	auth0 "github.com/auth0-community/go-auth0"
 	jose "gopkg.in/square/go-jose.v2"
 
-	"github.com/devopsfaith/krakend-jose/secrets"
+	"github.com/instill-ai/krakend-jose/secrets"
 )
 
 type SecretProviderConfig struct {

--- a/jwk_test.go
+++ b/jwk_test.go
@@ -12,7 +12,7 @@ import (
 	"sync/atomic"
 	"testing"
 
-	"github.com/devopsfaith/krakend-jose/secrets"
+	"github.com/instill-ai/krakend-jose/secrets"
 )
 
 func TestJWK(t *testing.T) {

--- a/jws.go
+++ b/jws.go
@@ -12,8 +12,8 @@ import (
 )
 
 const (
-	ValidatorNamespace = "github.com/devopsfaith/krakend-jose/validator"
-	SignerNamespace    = "github.com/devopsfaith/krakend-jose/signer"
+	ValidatorNamespace = "github.com/instill-ai/krakend-jose/validator"
+	SignerNamespace    = "github.com/instill-ai/krakend-jose/signer"
 	defaultRolesKey    = "roles"
 )
 

--- a/mux/jose.go
+++ b/mux/jose.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 
 	"github.com/auth0-community/go-auth0"
-	krakendjose "github.com/devopsfaith/krakend-jose"
+	krakendjose "github.com/instill-ai/krakend-jose"
 	"github.com/luraproject/lura/config"
 	"github.com/luraproject/lura/logging"
 	"github.com/luraproject/lura/proxy"

--- a/mux/jose_example_test.go
+++ b/mux/jose_example_test.go
@@ -10,7 +10,7 @@ import (
 	"os"
 	"time"
 
-	krakendjose "github.com/devopsfaith/krakend-jose"
+	krakendjose "github.com/instill-ai/krakend-jose"
 	"github.com/luraproject/lura/config"
 	"github.com/luraproject/lura/logging"
 	"github.com/luraproject/lura/proxy"


### PR DESCRIPTION
**Why**

When validating the JWT token, the original [krakend-jose](https://www.krakend.io/docs/authorization/jwt-validation/) only supports space-delimited scopes, e.g:
```
{
  ...
  "my_scopes": "scope1 scope2"
}
```

This PR makes `krakend-jose` also support scope list for both kinds of `scopes_matcher` (`all` and `any`), e.g:
```
{
  ...
  "my_scopes": ["scope1", "scope2"]
}
```